### PR TITLE
Update Claude GitHub Action workflow permissions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,9 +19,9 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
     steps:
       - name: Checkout repository
@@ -31,7 +31,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: Akira-Papa/claude-code-action@beta
+        uses: RTARO-LAB/claude-code-action@main
         with:
           # Option 1: Use Anthropic API key (commented out for OAuth)
           # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
   ## 概要
   Claude Code用のGitHub Actionsワークフローの権限を更新
   
   ## 変更内容
   - ワークフロー権限をreadからwriteに変更
   - OAuth認証設定を維持
   - Issue/PRコメントで @claude トリガーに対応
   
   ## テスト方法
   1. PRマージ後、Issueを作成
   2. コメントに `@claude` を含めて投稿
   3. GitHub Actionsが動作することを確認